### PR TITLE
Updated simpleitk to fix yanked release

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setuptools.setup(
     packages=['brats_toolkit'],
     zip_safe=False,
     install_requires=[
-        'SimpleITK==2.1.1.1',
+        'SimpleITK==2.1.1.2',
         'numpy==1.22.0',
         'python-engineio==3.14.2',
         'python-socketio==4.6.1',


### PR DESCRIPTION
In the setup.py SimpleiTK version 2.1.1.1 is specified. However this is a yanked release, so this version can no longer be installed. See also the issue over at the brats-toolkit repo: https://github.com/neuronflow/BraTS-Toolkit/issues/19

See here the page for SimpleITK version 2.1.1.1 which specifies that it is a yanked release: https://pypi.org/project/SimpleITK/2.1.1.1/

This pull request instead uses version 2.1.1.2 